### PR TITLE
add early failure and add runtime this support

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,19 @@
  */
 function promiseify(method, ctx) {
 
+  // check first
+  if (typeof method !== 'function') {
+    throw new TypeError(String(method) + ' is not a function');
+  }
+
   return function() {
 
+    // runtime args
     var args = [].slice.call(arguments);
+
+    // runtime this
+    ctx = ctx || this;
+
     return new Promise(function(resolve, reject) {
 
       args.push(function(err) {
@@ -27,7 +37,7 @@ function promiseify(method, ctx) {
       try {
         method.apply(ctx, args);
       } catch (err) {
-        reject(new TypeError(String(method) + ' is not a function'));
+        reject(err);
       }
     });
   };


### PR DESCRIPTION
## early failure

`promisify(method, ctx)` if `method` is not a function, throw immediately!

## runtime ctx support

1. if `promiseify(method, ctx)` is provided, then we use the `ctx`
2. if `ctx` not provided, we use the `this` value when the promisified function being called.